### PR TITLE
Set poison type to string

### DIFF
--- a/packages/server/ts/game/entity/character/character.ts
+++ b/packages/server/ts/game/entity/character/character.ts
@@ -239,7 +239,7 @@ class Character extends Entity {
             this.hitPointsCallback();
     }
 
-    setPoison(poison: boolean) {
+    setPoison(poison: string) {
 
         this.poison = poison;
 

--- a/packages/server/ts/game/entity/character/player/handler.ts
+++ b/packages/server/ts/game/entity/character/player/handler.ts
@@ -290,7 +290,7 @@ class Handler {
             timeDiff = new Date().getTime() - info[0];
 
         if (timeDiff > info[1]) {
-            this.player.setPoison(false);
+            this.player.setPoison('');
             return;
         }
 


### PR DESCRIPTION
### Motivation

`npm run build` throws an error: `ts/game/entity/character/player/handler.ts(293,35): error TS2345: Argument of type 'false' is not assignable to parameter of type 'string'.`

Setting `poison` to an empty string will make the parameter type-compatible and falsy.

This PR needs to be merged to make automatic builds work.

**How to test (feature)**

The application should build
