### PR TITLE
Create `FUNDING.yml`

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,12 @@
+# These are supported funding model platforms
+
+# github: [Veradictus, lemueldls, frycz, brion-fuller]
+patreon: kaetram
+open_collective: kaetram
+# ko_fi: # Replace with a single Ko-fi username
+# tidelift: # Replace with a single Tidelift platform-name/package-name e.g., npm/babel
+# community_bridge: # Replace with a single Community Bridge project-name e.g., cloud-foundry
+# liberapay: # Replace with a single Liberapay username
+# issuehunt: # Replace with a single IssueHunt username
+# otechie: # Replace with a single Otechie username
+# custom: # Replace with up to 4 custom sponsorship URLs e.g., ['link1', 'link2']


### PR DESCRIPTION
GitHub accounts enrolled with GitHub Sponsors can be added to the `github` field.
If also possible, PayPal accounts can be added to the `custom` field (i.e. `custom: ["https://www.paypal.me/octocat", octocat.com]`).

There are also other compatible funding services that have been commented out such as `ko_fi`, `tidelift`, `community_bridge`, `liberapay`, `issuehunt`, or `otechie`.
