### PR TITLE
Fixed stack count in bank/shop, teleport level requirement and show total stack sell value

### DIFF
--- a/packages/client/src/menu/bank.ts
+++ b/packages/client/src/menu/bank.ts
@@ -56,7 +56,7 @@ export default class Bank {
             slot.on('click', (event) => this.click('bank', event));
 
             const count = item.count;
-            let itemCount: string;
+            let itemCount: string = count.toString();
 
             if (count > 999999)
                 itemCount = `${count
@@ -101,7 +101,7 @@ export default class Bank {
             iSlot.on('click', (event) => this.click('inventory', event));
 
             const count = iItem.count;
-            let itemCount;
+            let itemCount = count.toString();
 
             if (count > 999999)
                 itemCount = `${count

--- a/packages/client/src/menu/shop.ts
+++ b/packages/client/src/menu/shop.ts
@@ -19,6 +19,7 @@ export default class Shop {
     shop: JQuery;
     inventory: JQuery;
     sellSlot: JQuery;
+    sellSlotText: JQuery;
     sellSlotReturn: JQuery;
     sellSlotReturnText: JQuery;
     confirmSell: JQuery;
@@ -46,6 +47,7 @@ export default class Shop {
          */
 
         this.sellSlot = $('#shopSellSlot');
+        this.sellSlotText = $('#shopSellSlotText');
         this.sellSlotReturn = $('#shopSellSlotReturn');
         this.sellSlotReturnText = $('#shopSellSlotReturnText');
 
@@ -108,7 +110,11 @@ export default class Shop {
             backgroundSize: this.sellSlot.css('background-size')
         });
 
-        this.sellSlotReturnText.text(info.price);
+        var quantity: number = Number(slotText.text()) || 1;
+
+        this.sellSlotText.text(slotText.text());
+
+        this.sellSlotReturnText.text(info.price * quantity);
 
         slotImage.css('background-image', '');
         slotText.text('');
@@ -120,8 +126,13 @@ export default class Shop {
         inventorySlot
             .find(`#inventoryImage${index}`)
             .css('background-image', this.sellSlot.css('background-image'));
+        
+        inventorySlot
+            .find(`#inventoryItemCount${index}`)
+            .text(this.sellSlotText.text());
 
         this.sellSlot.css('background-image', '');
+        this.sellSlotText.text('');
         this.sellSlotReturn.css('background-image', '');
         this.sellSlotReturnText.text('');
     }
@@ -224,6 +235,11 @@ export default class Shop {
 
     hide(): void {
         this.openShop = -1;
+
+        this.sellSlot.css('background-image', '');
+        this.sellSlotText.text('');
+        this.sellSlotReturn.css('background-image', '');
+        this.sellSlotReturnText.text('');
 
         this.body.fadeOut('fast');
     }

--- a/packages/server/src/game/entity/character/player/warp.ts
+++ b/packages/server/src/game/entity/character/player/warp.ts
@@ -59,7 +59,7 @@ class Warp {
     }
 
     hasRequirement(levelRequirement: number) {
-        return this.player.level > levelRequirement || this.player.rights > 1;
+        return this.player.level >= levelRequirement || this.player.rights > 1;
     }
 
     getDuration() {


### PR DESCRIPTION
- Display stack count on bank/shop screen
- Fix teleport requirement
- Show the the total currency return for selling all of the item stack in contrast with one
- Clear the item currently for sale to match the enchant screen