### PR TITLE
fix(regions): Fixed a typescript error caused by ||= statement.

### DIFF
--- a/packages/server/src/game/map/regions.ts
+++ b/packages/server/src/game/map/regions.ts
@@ -393,7 +393,7 @@ export default class Regions {
 
     private buildTile(x: number, y: number, index?: number): TileInfo {
         // Use the specified index if not undefined or calculate it.
-        index = index || this.map.coordToIndex(x, y);
+        index ||= this.map.coordToIndex(x, y);
 
         let tile: TileInfo = {
             x,

--- a/packages/server/src/game/map/regions.ts
+++ b/packages/server/src/game/map/regions.ts
@@ -392,8 +392,8 @@ export default class Regions {
      */
 
     private buildTile(x: number, y: number, index?: number): TileInfo {
-        // Calculate our index or use the one specified if not undefined.
-        index ||= this.map.coordToIndex(x, y);
+        // Use the specified index if not undefined or calculate it.
+        index = index || this.map.coordToIndex(x, y);
 
         let tile: TileInfo = {
             x,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "strict": true,
-        "target": "esnext",
+        "target": "es2019",
 
         "esModuleInterop": true,
         "moduleResolution": "node",


### PR DESCRIPTION
### Motivation

I cannot build the project without this fix on my mac

I get the following error:

Kaetram-Open/packages/server/src/game/map/regions.ts:301
➤ YN0000: [@kaetram/server]:         index ||= this.map.coordToIndex(x, y);
➤ YN0000: [@kaetram/server]:               ^^^
➤ YN0000: [@kaetram/server]: 
➤ YN0000: [@kaetram/server]: SyntaxError: Unexpected token '||='
➤ YN0000: [@kaetram/server]:     at wrapSafe (internal/modules/cjs/loader.js:1001:16)
➤ YN0000: [@kaetram/server]:     at Module._compile (internal/modules/cjs/loader.js:1049:27)
➤ YN0000: [@kaetram/server]:     at Module._compile (/Kaetram-Open/.yarn/cache/source-map-support-npm-0.5.19-65b33ae61e-c72802fdba.zip/node_modules/source-map-support/source-map-support.js:547:25)
