### PR TITLE
feat(monorepo): made packages includes less strict via star includes

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -6,7 +6,7 @@
         "start": "sirv dist -p 9000 --no-logs"
     },
     "dependencies": {
-        "@kaetram/common": "workspace:packages/common",
+        "@kaetram/common": "workspace:*",
         "gl-tiled": "^1.0.0",
         "illuminated": "^1.2.3",
         "jquery": "^3.6.0",
@@ -26,7 +26,7 @@
         "autoprefixer": "^10.4.2",
         "dotenv-extended": "^2.9.0",
         "dotenv-parse-variables": "^2.0.0",
-        "kaetram": "workspace:.",
+        "kaetram": "workspace:*",
         "postcss": "^8.4.8",
         "postcss-custom-media": "^8.0.0",
         "postcss-preset-env": "^7.4.2",

--- a/packages/hub/package.json
+++ b/packages/hub/package.json
@@ -6,7 +6,7 @@
         "hub": "ts-node-dev ./src/main.ts"
     },
     "dependencies": {
-        "@kaetram/common": "workspace:packages/common",
+        "@kaetram/common": "workspace:*",
         "axios": "^0.26.1",
         "body-parser": "^1.19.2",
         "discord.js": "^12.5.3",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -6,7 +6,7 @@
         "build": "tsc --noEmit && ts-node build"
     },
     "dependencies": {
-        "@kaetram/common": "workspace:packages/common",
+        "@kaetram/common": "workspace:*",
         "axios": "^0.26.1",
         "bcryptjs": "^2.4.3",
         "body-parser": "^1.19.2",
@@ -22,7 +22,7 @@
         "ws": "^8.5.0"
     },
     "devDependencies": {
-        "@kaetram/tools": "workspace:packages/tools",
+        "@kaetram/tools": "workspace:*",
         "@types/bcryptjs": "^2.4.2",
         "@types/body-parser": "^1.19.2",
         "@types/dotenv-parse-variables": "^2.0.1",

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -6,8 +6,8 @@
         "map": "yarn exportmap map/data/map.json"
     },
     "dependencies": {
-        "@kaetram/common": "workspace:packages/common",
-        "@kaetram/server": "workspace:packages/server",
+        "@kaetram/common": "workspace:*",
+        "@kaetram/server": "workspace:*",
         "lodash": "^4.17.21",
         "socket.io-client": "^4.4.1"
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1681,7 +1681,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@kaetram/client@workspace:packages/client"
   dependencies:
-    "@kaetram/common": "workspace:packages/common"
+    "@kaetram/common": "workspace:*"
     "@types/dotenv-parse-variables": ^2.0.1
     "@types/html-minifier-terser": ^6.1.0
     "@types/jquery": ^3.5.14
@@ -1696,7 +1696,7 @@ __metadata:
     gl-tiled: ^1.0.0
     illuminated: ^1.2.3
     jquery: ^3.6.0
-    kaetram: "workspace:."
+    kaetram: "workspace:*"
     lodash: ^4.17.21
     pako: ^2.0.4
     postcss: ^8.4.8
@@ -1718,7 +1718,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@kaetram/common@workspace:packages/common":
+"@kaetram/common@workspace:*, @kaetram/common@workspace:packages/common":
   version: 0.0.0-use.local
   resolution: "@kaetram/common@workspace:packages/common"
   dependencies:
@@ -1735,7 +1735,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@kaetram/hub@workspace:packages/hub"
   dependencies:
-    "@kaetram/common": "workspace:packages/common"
+    "@kaetram/common": "workspace:*"
     "@types/body-parser": ^1.19.2
     "@types/dotenv-parse-variables": ^2.0.1
     "@types/express": ^4.17.13
@@ -1757,12 +1757,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@kaetram/server@workspace:packages/server":
+"@kaetram/server@workspace:*, @kaetram/server@workspace:packages/server":
   version: 0.0.0-use.local
   resolution: "@kaetram/server@workspace:packages/server"
   dependencies:
-    "@kaetram/common": "workspace:packages/common"
-    "@kaetram/tools": "workspace:packages/tools"
+    "@kaetram/common": "workspace:*"
+    "@kaetram/tools": "workspace:*"
     "@types/bcryptjs": ^2.4.2
     "@types/body-parser": ^1.19.2
     "@types/dotenv-parse-variables": ^2.0.1
@@ -1792,12 +1792,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@kaetram/tools@workspace:packages/tools":
+"@kaetram/tools@workspace:*, @kaetram/tools@workspace:packages/tools":
   version: 0.0.0-use.local
   resolution: "@kaetram/tools@workspace:packages/tools"
   dependencies:
-    "@kaetram/common": "workspace:packages/common"
-    "@kaetram/server": "workspace:packages/server"
+    "@kaetram/common": "workspace:*"
+    "@kaetram/server": "workspace:*"
     "@types/lodash": ^4.14.180
     "@types/node": ^17.0.21
     lodash: ^4.17.21
@@ -7250,7 +7250,7 @@ fsevents@~2.3.2:
   languageName: node
   linkType: hard
 
-"kaetram@workspace:.":
+"kaetram@workspace:*, kaetram@workspace:.":
   version: 0.0.0-use.local
   resolution: "kaetram@workspace:."
   dependencies:


### PR DESCRIPTION
### Motivation

I made packages includes less strict via star includes. This will allow people to add the repo inside another monorepo and mix and match includes.

On top of that it is recommended to use star includes over the relative path includes on the yarn website anyway:
https://yarnpkg.com/features/workspaces

> - If a semver range, it will select the workspace matching the specified version.
> - If a project-relative path, it will select the workspace that match this path (experimental).
> 
> Note that the second flavor is experimental and we advise against using it for now, as some details might change in the future. Our current recommendation is to use workspace:*, which will almost always do what you expect.)
