### PR TITLE
feat(Entities): More modular and pluggable entity collections

### DIFF
--- a/packages/server/src/game/entity/collection/all.ts
+++ b/packages/server/src/game/entity/collection/all.ts
@@ -8,21 +8,24 @@ import log from '@kaetram/common/util/log';
 import { Despawn } from '@kaetram/server/src/network/packets';
 import Character from '@kaetram/server/src/game/entity/character/character';
 import _ from 'lodash';
+import Collections from '@kaetram/server/src/game/entity/collection/collections';
 
 /**
  * A class for collections of entities of a certain type in the game.
  */
 export default class AllCollection {
+    private world: World;
     private map: Map;
     private regions: Regions;
     private grids: Grids;
 
     private entities: { [instance: string]: Entity } = {};
 
-    public constructor(protected world: World) {
-        this.map = world.map;
-        this.regions = world.map.regions;
-        this.grids = world.map.grids;
+    public constructor(public readonly collections: Collections) {
+        this.world = collections.world;
+        this.map = this.world.map;
+        this.regions = this.world.map.regions;
+        this.grids = this.world.map.grids;
     }
 
     /**

--- a/packages/server/src/game/entity/collection/chests.ts
+++ b/packages/server/src/game/entity/collection/chests.ts
@@ -1,23 +1,12 @@
-import World from '@kaetram/server/src/game/world';
 import Collection from '@kaetram/server/src/game/entity/collection/collection';
 import Chest from '@kaetram/server/src/game/entity/objects/chest';
-import ItemCollection from '@kaetram/server/src/game/entity/collection/items';
 import Player from '@kaetram/server/src/game/entity/character/player/player';
-import AllCollection from '@kaetram/server/src/game/entity/collection/all';
 
 /**
  * A class for collections of entities of a certain type in the game.
  */
 export default class ChestCollection extends Collection<Chest> {
-    public constructor(
-        world: World,
-        allEntities: AllCollection,
-        protected itemEntityCollection: ItemCollection
-    ) {
-        super(world, allEntities);
-    }
-
-    onSpawn(params: {
+    createEntity(params: {
         items: string[];
         x: number;
         y: number;
@@ -55,7 +44,7 @@ export default class ChestCollection extends Collection<Chest> {
 
             if (!item) return;
 
-            this.itemEntityCollection.spawn({
+            this.collections.items.spawn({
                 key: item.string,
                 x: chest.x,
                 y: chest.y,

--- a/packages/server/src/game/entity/collection/collection.ts
+++ b/packages/server/src/game/entity/collection/collection.ts
@@ -18,6 +18,7 @@ export default abstract class Collection<EntityType extends Entity> {
     protected entities: { [instance: string]: EntityType } = {};
 
     public constructor(public readonly collections: Collections) {
+        collections.register<Collection<EntityType>>(this);
         this.world = collections.world;
         this.map = this.world.map;
         this.regions = this.world.map.regions;

--- a/packages/server/src/game/entity/collection/collections.ts
+++ b/packages/server/src/game/entity/collection/collections.ts
@@ -1,0 +1,58 @@
+import World from '@kaetram/server/src/game/world';
+import AllCollection from '@kaetram/server/src/game/entity/collection/all';
+import PlayerCollection from '@kaetram/server/src/game/entity/collection/players';
+import ItemCollection from '@kaetram/server/src/game/entity/collection/items';
+import MobCollection from '@kaetram/server/src/game/entity/collection/mobs';
+import ChestCollection from '@kaetram/server/src/game/entity/collection/chests';
+import NpcCollection from '@kaetram/server/src/game/entity/collection/npcs';
+import ProjectileCollection from '@kaetram/server/src/game/entity/collection/projectiles';
+import Collection from '@kaetram/server/src/game/entity/collection/collection';
+import _ from 'lodash';
+import log from '@kaetram/common/util/log';
+
+/**
+ * A class for collections of entities of a certain type in the game.
+ */
+export default class Collections {
+    public readonly allEntities: AllCollection;
+    public readonly players: PlayerCollection;
+    public readonly items: ItemCollection;
+    public readonly mobs: MobCollection;
+    public readonly chests: ChestCollection;
+    public readonly npcs: NpcCollection;
+    public readonly projectiles: ProjectileCollection;
+    private readonly all: Collection<any>[] = [];
+
+    public constructor(public world: World) {
+        this.allEntities = new AllCollection(this);
+        this.players = this.register<PlayerCollection>(new PlayerCollection(this));
+        this.items = this.register<ItemCollection>(new ItemCollection(this));
+        this.mobs = this.register<MobCollection>(new MobCollection(this));
+        this.chests = this.register<ChestCollection>(new ChestCollection(this));
+        this.npcs = this.register<NpcCollection>(new NpcCollection(this));
+        this.projectiles = this.register<ProjectileCollection>(new ProjectileCollection(this));
+    }
+
+    /**
+     * Register a collection for easy iteration
+     */
+    public register<T extends Collection<any>>(collection: T): T {
+        if (!this.all.includes(collection)) {
+            if (this !== collection.collections) {
+                log.warning(
+                    'Collections reference does not match. Registering is skipped. Check your implementation!'
+                );
+                return collection;
+            }
+            this.all.push(collection);
+        }
+        return collection;
+    }
+
+    /**
+     * Perform a callback for each registered collection
+     */
+    forEachCollection(callback: (collection: Collection<any>) => void) {
+        _.each(this.all, callback);
+    }
+}

--- a/packages/server/src/game/entity/collection/collections.ts
+++ b/packages/server/src/game/entity/collection/collections.ts
@@ -25,18 +25,19 @@ export default class Collections {
 
     public constructor(public world: World) {
         this.allEntities = new AllCollection(this);
-        this.players = this.register<PlayerCollection>(new PlayerCollection(this));
-        this.items = this.register<ItemCollection>(new ItemCollection(this));
-        this.mobs = this.register<MobCollection>(new MobCollection(this));
-        this.chests = this.register<ChestCollection>(new ChestCollection(this));
-        this.npcs = this.register<NpcCollection>(new NpcCollection(this));
-        this.projectiles = this.register<ProjectileCollection>(new ProjectileCollection(this));
+        this.players = new PlayerCollection(this);
+        this.items = new ItemCollection(this);
+        this.mobs = new MobCollection(this);
+        this.chests = new ChestCollection(this);
+        this.npcs = new NpcCollection(this);
+        this.projectiles = new ProjectileCollection(this);
     }
 
     /**
      * Register a collection for easy iteration
      */
     public register<T extends Collection<any>>(collection: T): T {
+        log.debug(`Registering entity collection of type ${collection.constructor.name}`);
         if (!this.all.includes(collection)) {
             if (this !== collection.collections) {
                 log.warning(

--- a/packages/server/src/game/entity/collection/items.ts
+++ b/packages/server/src/game/entity/collection/items.ts
@@ -2,12 +2,23 @@ import Collection from '@kaetram/server/src/game/entity/collection/collection';
 import Item from '@kaetram/server/src/game/entity/objects/item';
 import { Blink } from '@kaetram/server/src/network/packets';
 import { Modules } from '@kaetram/common/network';
+import itemData from '@kaetram/server/data/items.json';
 
 /**
  * A class for collections of entities of a certain type in the game.
  */
 export default class ItemCollection extends Collection<Item> {
-    onSpawn(params: {
+    override tryLoad(position: Position, key: string): Item | undefined {
+        if (!(key in itemData)) return undefined;
+        return this.spawn({
+            key,
+            x: position.x,
+            y: position.y,
+            dropped: false
+        });
+    }
+
+    createEntity(params: {
         key: string;
         x: number;
         y: number;

--- a/packages/server/src/game/entity/collection/mobs.ts
+++ b/packages/server/src/game/entity/collection/mobs.ts
@@ -1,12 +1,18 @@
 import World from '@kaetram/server/src/game/world';
 import Mob from '@kaetram/server/src/game/entity/character/mob/mob';
 import Collection from '@kaetram/server/src/game/entity/collection/collection';
+import mobData from '@kaetram/server/data/mobs.json';
 
 /**
  * A class for collections of entities of a certain type in the game.
  */
 export default class MobCollection extends Collection<Mob> {
-    onSpawn(params: { world: World; key: string; x: number; y: number }): Mob {
+    override tryLoad(position: Position, key: string): Mob | undefined {
+        if (!(key in mobData)) return undefined;
+        return this.spawn({ world: this.world, key, x: position.x, y: position.y });
+    }
+
+    createEntity(params: { world: World; key: string; x: number; y: number }): Mob {
         return new Mob(params.world, params.key, params.x, params.y);
     }
 

--- a/packages/server/src/game/entity/collection/npcs.ts
+++ b/packages/server/src/game/entity/collection/npcs.ts
@@ -1,11 +1,17 @@
 import Collection from '@kaetram/server/src/game/entity/collection/collection';
 import NPC from '@kaetram/server/src/game/entity/npc/npc';
+import npcData from '@kaetram/server/data/npcs.json';
 
 /**
  * A class for collections of entities of a certain type in the game.
  */
 export default class NpcCollection extends Collection<NPC> {
-    onSpawn(params: { key: string; x: number; y: number }): NPC {
+    override tryLoad(position: Position, key: string): NPC | undefined {
+        if (!(key in npcData)) return undefined;
+        return this.spawn({ key, x: position.x, y: position.y });
+    }
+
+    createEntity(params: { key: string; x: number; y: number }): NPC {
         return new NPC(params.key, params.x, params.y);
     }
 }

--- a/packages/server/src/game/entity/collection/players.ts
+++ b/packages/server/src/game/entity/collection/players.ts
@@ -5,7 +5,7 @@ import Player from '@kaetram/server/src/game/entity/character/player/player';
  * A class for collections of entities of a certain type in the game.
  */
 export default class PlayerCollection extends Collection<Player> {
-    onSpawn(): Player | undefined {
+    createEntity(): Player | undefined {
         // We should not try to spawn a player this way, add() will not be called
         return undefined;
     }

--- a/packages/server/src/game/entity/collection/projectiles.ts
+++ b/packages/server/src/game/entity/collection/projectiles.ts
@@ -7,7 +7,7 @@ import Hit from '@kaetram/server/src/game/entity/character/combat/hit';
  * A class for collections of entities of a certain type in the game.
  */
 export default class ProjectileCollection extends Collection<Projectile> {
-    onSpawn(params: { owner: Character; target: Character; hit: Hit }): Projectile {
+    createEntity(params: { owner: Character; target: Character; hit: Hit }): Projectile {
         return new Projectile(params.owner, params.target, params.hit);
     }
 }


### PR DESCRIPTION
Added notion of collections and the ability to register additional collections

### Motivation

For my own code base I want to limit the amount of changes I do to shared code. Because I want to create a new entity type called 'Spirit Constructs' I refactored the way collections of entities are managed so I can register an additional one without changes to the shared entity controller.

I also used this new structure to allow the loading process to happen generically and let the specific entity collections decide if they want to act on the load() trigger.

**How to test (feature)**

Like last one my changes are contained within the Entity controller and related classes. No functional changes have happened. So test for regression.
