### PR TITLE
fix(server): Fix player names not showing up for other players

### DIFF
--- a/packages/server/src/controllers/incoming.ts
+++ b/packages/server/src/controllers/incoming.ts
@@ -122,7 +122,6 @@ export default class Incoming {
         if (username) {
             // Format username by making it all lower case, shorter than 32 characters, and no spaces.
             this.player.username = username.toLowerCase().slice(0, 32).trim();
-            this.player.name = this.player.username;
 
             if (password) this.player.password = password.slice(0, 32);
             if (email) this.player.email = email;
@@ -146,7 +145,6 @@ export default class Incoming {
             case Opcodes.Login.Guest:
                 this.player.isGuest = true; // Makes sure player doesn't get saved to database.
                 this.player.username = `guest${Utils.counter}`; // Generate a random guest username.
-                this.player.name = this.player.username;
 
                 return this.player.load(Creator.serializePlayer(this.player));
         }

--- a/packages/server/src/controllers/incoming.ts
+++ b/packages/server/src/controllers/incoming.ts
@@ -122,6 +122,7 @@ export default class Incoming {
         if (username) {
             // Format username by making it all lower case, shorter than 32 characters, and no spaces.
             this.player.username = username.toLowerCase().slice(0, 32).trim();
+            this.player.name = this.player.username;
 
             if (password) this.player.password = password.slice(0, 32);
             if (email) this.player.email = email;
@@ -145,6 +146,7 @@ export default class Incoming {
             case Opcodes.Login.Guest:
                 this.player.isGuest = true; // Makes sure player doesn't get saved to database.
                 this.player.username = `guest${Utils.counter}`; // Generate a random guest username.
+                this.player.name = this.player.username;
 
                 return this.player.load(Creator.serializePlayer(this.player));
         }

--- a/packages/server/src/game/entity/character/player/player.ts
+++ b/packages/server/src/game/entity/character/player/player.ts
@@ -206,6 +206,7 @@ export default class Player extends Character {
      */
 
     public load(data: PlayerInfo): void {
+        this.name = data.username;
         this.rights = data.rights;
         this.experience = data.experience;
         this.ban = data.ban;


### PR DESCRIPTION
### Motivation

Currently the name of other players does not display because the name field is not set in the character object on the server.

This fixes that so that you can see the name of other players.

**How to test (feature)**

- Log in with 2 players
- You should see the other player's name

**How to test (potential regressions)**

/

### Changes

Filled in the name attribute on character server model when logging in.
