### PR TITLE
feat(client): optional configure of high rendered layers

### DIFF
--- a/.env.defaults
+++ b/.env.defaults
@@ -79,11 +79,11 @@ MODERATORS=,
 # === Discord ===
 
 # If to connect to Discord or not.
-DISCORD_ENABLED=false 
+DISCORD_ENABLED=false
 # The discord channel ID we are monitoring messages of
-DISCORD_CHANNEL_ID='' 
+DISCORD_CHANNEL_ID=''
 # The bot token used to interact with the server.
-DISCORD_BOT_TOKEN='' 
+DISCORD_BOT_TOKEN=''
 
 # === Debugging ===
 

--- a/packages/client/src/game.ts
+++ b/packages/client/src/game.ts
@@ -26,7 +26,7 @@ import Camera from './renderer/camera';
 import Overlay from './renderer/overlay';
 import Renderer from './renderer/renderer';
 import Updater from './renderer/updater';
-import { agent, supportsWebGL } from './utils/detect';
+import { agent } from './utils/detect';
 import Pathfinder from './utils/pathfinder';
 import Storage from './utils/storage';
 

--- a/packages/client/src/renderer/renderer.ts
+++ b/packages/client/src/renderer/renderer.ts
@@ -1122,10 +1122,7 @@ export default class Renderer {
 
             if (Array.isArray(indexData)) {
                 let layerIndex = 0;
-                for (let data of indexData) {
-                    callback(data, index, layerIndex);
-                    layerIndex++;
-                }
+                for (let data of indexData) callback(data, index, layerIndex++);
             } else if (this.map.data[index]) callback(this.map.data[index], index);
         }, offset);
     }

--- a/packages/common/network/modules.ts
+++ b/packages/common/network/modules.ts
@@ -296,6 +296,8 @@ export const enum Constants {
     TUTORIAL_SPAWN_POINT = '375,40' // 'x,y' values
 }
 
+export let HighLayerIndexes: number[] = [];
+
 export enum APIConstants {
     UNHANDLED_HTTP_METHOD,
     NOT_FOUND_ERROR,


### PR DESCRIPTION
Allow to configure some layers to be rendered as 'high' regardless of the map config

### Motivation

My game world has high and low layers instead of high and low tiles. This changes adds support for this to the game engine. High tiles still work correctly as well.

**How to test (feature)**

- Add a high layer index to the packages/common/network/modules.ts HighLayerIndexes array

**How to test (potential regressions)**

- Rendering of tiles should still be correctly under and over the character as expected
