### PR TITLE
fix(trees): Allow 1-tile trees right next to each other and logging fix

### DIFF
--- a/packages/server/src/game/globals/trees.ts
+++ b/packages/server/src/game/globals/trees.ts
@@ -39,9 +39,8 @@ export default class Trees {
             });
         });
 
-        log.info(
-            `Loaded ${this.trees.length} tree${Object.keys(this.trees).length > 1 ? 's' : ''}.`
-        );
+        let amount = Object.keys(this.trees).length;
+        log.info(`Loaded ${amount} tree${amount > 1 ? 's' : ''}.`);
     }
 
     /**
@@ -104,10 +103,12 @@ export default class Trees {
         this.map.data[index] = -1;
 
         // Search for tiles recursively right, left, down, up respectively.
-        if (this.search(treeInfo, tree, index + 1)) return true;
-        if (this.search(treeInfo, tree, index - 1)) return true;
-        if (this.search(treeInfo, tree, index + this.map.width)) return true;
-        if (this.search(treeInfo, tree, index - this.map.width)) return true;
+        if (treeInfo.data.length > 1) {
+            if (this.search(treeInfo, tree, index + 1)) return true;
+            if (this.search(treeInfo, tree, index - 1)) return true;
+            if (this.search(treeInfo, tree, index + this.map.width)) return true;
+            if (this.search(treeInfo, tree, index - this.map.width)) return true;
+        }
 
         return false;
     }


### PR DESCRIPTION
### Motivation

For single tile trees, stones etc etc they often are right next to each other. This fix prevents the problem of them being detected as 1 object.

**How to test (feature)**

- Configure a single tile tree and place some next to each other on the map
- See if an object is generated for every tree
- Also check the amount of tree log line during startup that was fixed as well.
