### PR TITLE
Fix/stop following dead target during combat

### DIFF
--- a/packages/server/src/game/entity/character/combat/combat.ts
+++ b/packages/server/src/game/entity/character/combat/combat.ts
@@ -83,7 +83,7 @@ export default class Combat {
      */
 
     private handleLoop(): void {
-        if (!this.character.hasTarget()) return this.stop();
+        if (!this.character.hasTarget() || this.character.target?.isDead()) return this.stop();
 
         if (this.character.isNearTarget() && this.canAttack()) {
             let hit = this.createHit();


### PR DESCRIPTION
### Motivation

Currently a player keeps following dead targets. This checks if they are dead and stops the combat.
