### PR TITLE
feat(quests): Allow dialog between NPC and player via quests

### DIFF
--- a/packages/common/types/quest.d.ts
+++ b/packages/common/types/quest.d.ts
@@ -1,6 +1,9 @@
 import type { PointerData } from './pointer';
 import type { PopupData } from './popup';
 
+export type Actor = 'player' | 'npc';
+export type DialogueItem = string | { actor: string; text: string };
+
 export interface RawStage {
     task: string;
     npc?: string;
@@ -18,7 +21,7 @@ export interface RawStage {
     itemCountRequirement?: number;
 
     /** Text for the NPC. */
-    text?: string[];
+    text?: DialogueItem[];
     completedText?: string[];
 
     /** Pointer information */
@@ -45,7 +48,7 @@ export interface StageData {
     mobCountRequirement: number; // how many mobs we need to kill to progress
     itemRequirement?: string;
     itemCountRequirement?: number; // how many of an item we need for progression
-    text?: string[];
+    text?: DialogueItem[];
     completedText?: string[];
     pointer?: PointerData;
     popup?: PopupData;

--- a/packages/server/src/game/entity/character/player/quest/quest.ts
+++ b/packages/server/src/game/entity/character/player/quest/quest.ts
@@ -6,7 +6,7 @@ import Player from '../player';
 
 import log from '@kaetram/common/util/log';
 
-import { QuestData, RawQuest, RawStage, StageData } from '@kaetram/common/types/quest';
+import { DialogueItem, QuestData, RawQuest, RawStage, StageData } from '@kaetram/common/types/quest';
 import { PointerData } from '@kaetram/common/types/pointer';
 import { ProcessedDoor } from '@kaetram/common/types/map';
 import Item from '../../../objects/item';
@@ -87,7 +87,7 @@ export default abstract class Quest {
         log.debug(`[${this.name}] Talking to NPC: ${npc.key} - stage: ${this.stage}.`);
 
         // Extract the dialogue for the NPC.
-        let dialogue = this.getNPCDialogue(npc);
+        let dialogue = this.getQuestDialogue(npc);
 
         /**
          * Ends the conversation. If the player has the required item in the inventory
@@ -277,7 +277,7 @@ export default abstract class Quest {
      * @returns An array of strings containing the dialogue.
      */
 
-    private getNPCDialogue(npc: NPC): string[] {
+    private getQuestDialogue(npc: NPC): DialogueItem[] {
         // Iterate backwards, last reference of the NPC is the text we grab.
         for (let i = this.stage; i > -1; i--) {
             // We do not count iterations of stages above stage we are currently on.


### PR DESCRIPTION
### Motivation

Allow bubbles to appear over the player and have a conversation during a quest dialogue.

This is backwards compatible with the existing quests.

**How to test (feature)**

Edit the quests.json
`
...
"stages": {
            "0": {
                "task": "talk",
                "npc": "qieros",
                "text": [
                    { "actor": "player", "text": "What is this? It’s so.. sparkly" },
                    "Hey! Watch it, buddy!  Who are you calling ‘sparkly’",
                    { "actor": "player", "text": "You.. you can talk?!  What are you?" },
                    "Of course I can talk, genius",
...
`
![image](https://user-images.githubusercontent.com/8372769/170595389-92c32f59-9c6d-48df-9dfe-86e96b254926.png)
