### PR TITLE
Add death callback to minions

### DIFF
--- a/packages/server/data/plugins/mobs/ogrelord.ts
+++ b/packages/server/data/plugins/mobs/ogrelord.ts
@@ -35,6 +35,13 @@ export default class OgreLord extends Default {
         setInterval(() => this.randomDialogue(), 15_000);
     }
 
+    /**
+     * Override for the hit callback. When the Ogre Lord falls beneath
+     * 50% and 25% health, he will spawn minions.
+     * @param damage Damage being dealt to the mob.
+     * @param attacker (Optional) The attacker who is dealing the damage.
+     */
+
     protected override handleHit(damage: number, attacker?: Character): void {
         super.handleHit(damage, attacker);
 
@@ -49,8 +56,10 @@ export default class OgreLord extends Default {
     protected override handleDeath(attacker?: Character): void {
         super.handleDeath(attacker);
 
-        this.despawn();
+        // Removes all the minions from the list.
+        _.each(this.minions, (minion: Mob) => minion.deathCallback?.());
 
+        // Clear all boss properties.
         this.firstWaveMinions = false;
         this.secondWaveMinions = false;
     }
@@ -80,6 +89,11 @@ export default class OgreLord extends Default {
             // Prevent minion from respawning after death.
             minion.respawnable = false;
 
+            // Remove minion from the list when it dies.
+            minion.onDeathImpl(() => {
+                this.minions.splice(this.minions.indexOf(minion), 1);
+            });
+
             // Add the minion to the list of minions.
             this.minions.push(minion);
 
@@ -99,14 +113,6 @@ export default class OgreLord extends Default {
 
         // Spawn minions text message.
         this.mob.talkCallback?.('My minions will surely help defeat you!');
-    }
-
-    /**
-     * Removes all the minions from the world.
-     */
-
-    private despawn(): void {
-        _.each(this.minions, (minion: Mob) => minion.deathCallback?.());
     }
 
     /**

--- a/packages/server/data/plugins/mobs/skeletonking.ts
+++ b/packages/server/data/plugins/mobs/skeletonking.ts
@@ -1,0 +1,36 @@
+import _ from 'lodash';
+
+import Default from './default';
+
+import Mob from '@kaetram/server/src/game/entity/character/mob/mob';
+import Character from '@kaetram/server/src/game/entity/character/character';
+
+const MAX_MINIONS = 10;
+
+export default class SkeletonKing extends Default {
+    private minions: Mob[] = [];
+
+    public constructor(mob: Mob) {
+        super(mob);
+
+        setInterval(() => this.spawn, 15_000);
+    }
+
+    /**
+     * Override for the handle death callback. The skeleton king must remove
+     * all of its minions upon death.
+     * @param attacker The attacker that killed the skeleton king.
+     */
+
+    protected override handleDeath(attacker?: Character): void {
+        super.handleDeath(attacker);
+
+        // Clear all the minions from the list.
+        _.each(this.minions, (minion: Mob) => minion.deathCallback?.());
+    }
+
+    private spawn(): void {
+        // Maximum number of minions has been reached.
+        if (this.minions.length >= MAX_MINIONS) return;
+    }
+}

--- a/packages/server/src/game/entity/character/character.ts
+++ b/packages/server/src/game/entity/character/character.ts
@@ -62,6 +62,7 @@ export default abstract class Character extends Entity {
 
     public hitCallback?: HitCallback;
     public deathCallback?: DeathCallback;
+    public deathICallback?: DeathCallback;
 
     protected constructor(
         instance: string,
@@ -568,7 +569,18 @@ export default abstract class Character extends Entity {
      * @param callback Contains the attacker that killed the character if not undefined.
      */
 
-    public onDeath(callback: (attacker?: Character) => void): void {
+    public onDeath(callback: DeathCallback): void {
         this.deathCallback = callback;
+    }
+
+    /**
+     * A secondary callback for when the character dies. Generally used for instances
+     * where we cannot write a plugin for the mob itself, and we only want to manipulate
+     * the effects of the death without impeding the actual death callback.
+     * @param callback Contains an optional parameter for the attacker.
+     */
+
+    public onDeathImpl(callback: DeathCallback): void {
+        this.deathICallback = callback;
     }
 }

--- a/packages/server/src/game/entity/character/mob/handler.ts
+++ b/packages/server/src/game/entity/character/mob/handler.ts
@@ -92,6 +92,9 @@ export default class Handler {
         // Respawn the chest associated with the mob.
         this.mob.chest?.respawn();
 
+        // Call the secondary death callback.
+        this.mob.deathICallback?.(attacker);
+
         // Despawn entity from the world.
         this.world.entities.remove(this.mob);
         this.world.cleanCombat(this.mob);

--- a/packages/server/src/game/entity/character/mob/mob.ts
+++ b/packages/server/src/game/entity/character/mob/mob.ts
@@ -57,6 +57,7 @@ export default class Mob extends Character {
     private handler?: MobHandler | DefaultPlugin;
 
     private respawnCallback?: () => void;
+
     public talkCallback?: (message: string) => void;
     public roamingCallback?: () => void;
 


### PR DESCRIPTION
Adds a secondary death callback called during the initial death callback. This is used for mobs such as boss minions when we want to add an effect upon their death.