### PR TITLE
feat(server): Better roaming for mobs

### DIFF
--- a/packages/common/network/modules.ts
+++ b/packages/common/network/modules.ts
@@ -384,7 +384,7 @@ export enum MobDefaults {
     AGGRO_RANGE = 2, // Default aggro range of 2 tiles
     RESPAWN_DELAY = 60_000, // 60 seconds to respawn
     ROAM_DISTANCE = 7, // 7 tiles away from spawn point
-    ROAM_FREQUENCY = 17_000, // Roam interval every 17 seconds
+    ROAM_FREQUENCY = 10_000, // Roam interval every 10 seconds
     DEFENSE_LEVEL = 1,
     ATTACK_LEVEL = 1
 }

--- a/packages/common/network/modules.ts
+++ b/packages/common/network/modules.ts
@@ -385,6 +385,7 @@ export enum MobDefaults {
     RESPAWN_DELAY = 60_000, // 60 seconds to respawn
     ROAM_DISTANCE = 7, // 7 tiles away from spawn point
     ROAM_FREQUENCY = 10_000, // Roam interval every 10 seconds
+    ROAM_RETRIES = 5, // 5 retries if the new spot is not possible
     DEFENSE_LEVEL = 1,
     ATTACK_LEVEL = 1
 }

--- a/packages/server/src/game/entity/character/mob/handler.ts
+++ b/packages/server/src/game/entity/character/mob/handler.ts
@@ -123,7 +123,8 @@ export default class Handler {
      * mobs do not walk outside a predefined boundary of theirs.
      */
 
-    protected handleRoaming(): void {
+    protected handleRoaming(retries = 0): void {
+        if (retries < 0) return;
         // Ensure the mob isn't dead first.
         if (this.mob.dead) return;
 
@@ -136,10 +137,16 @@ export default class Handler {
         if (combat.started) return;
 
         // Prevent mobs from going outside of their roaming radius.
-        if (distance < roamDistance) return;
+        if (distance < roamDistance) {
+            this.handleRoaming(--retries);
+            return;
+        }
 
         // No need to move if the new position is the same as the current.
-        if (newX === x && newY === y) return;
+        if (newX === x && newY === y) {
+            this.handleRoaming(--retries);
+            return;
+        }
 
         /**
          * A plateau defines an imaginary z-axis in a 2D space. A mob is essentially
@@ -153,10 +160,16 @@ export default class Handler {
         if (plateauLevel !== this.map.getPlateauLevel(newX, newY)) return;
 
         // Check if the new position is a collision.
-        if (this.map.isColliding(newX, newY)) return;
+        if (this.map.isColliding(newX, newY)) {
+            this.handleRoaming(--retries);
+            return;
+        }
 
         // Don't have mobs block a door.
-        if (this.map.isDoor(newX, newY)) return;
+        if (this.map.isDoor(newX, newY)) {
+            this.handleRoaming(--retries);
+            return;
+        }
 
         this.mob.move(newX, newY);
     }

--- a/packages/server/src/game/entity/character/mob/mob.ts
+++ b/packages/server/src/game/entity/character/mob/mob.ts
@@ -59,7 +59,7 @@ export default class Mob extends Character {
     private respawnCallback?: () => void;
 
     public talkCallback?: (message: string) => void;
-    public roamingCallback?: () => void;
+    public roamingCallback?: (retries: number) => void;
 
     public constructor(world: World, key: string, x: number, y: number) {
         super(Utils.createInstance(Modules.EntityType.Mob), world, key, x, y);
@@ -116,7 +116,10 @@ export default class Mob extends Character {
 
         // The roaming interval if the mob is a roaming entity.
         if (data.roaming)
-            setInterval(() => this.roamingCallback?.(), Modules.MobDefaults.ROAM_FREQUENCY);
+            setTimeout(() => {
+                this.roamingCallback?.(5);
+                setInterval(() => this.roamingCallback?.(5), Modules.MobDefaults.ROAM_FREQUENCY);
+            }, Utils.randomInt(0, Modules.MobDefaults.ROAM_FREQUENCY - 1));
     }
 
     /**

--- a/packages/server/src/game/entity/character/mob/mob.ts
+++ b/packages/server/src/game/entity/character/mob/mob.ts
@@ -59,7 +59,7 @@ export default class Mob extends Character {
     private respawnCallback?: () => void;
 
     public talkCallback?: (message: string) => void;
-    public roamingCallback?: (retries: number) => void;
+    public roamingCallback?: (retries?: number) => void;
 
     public constructor(world: World, key: string, x: number, y: number) {
         super(Utils.createInstance(Modules.EntityType.Mob), world, key, x, y);

--- a/packages/server/src/game/entity/character/mob/mob.ts
+++ b/packages/server/src/game/entity/character/mob/mob.ts
@@ -117,8 +117,11 @@ export default class Mob extends Character {
         // The roaming interval if the mob is a roaming entity.
         if (data.roaming)
             setTimeout(() => {
-                this.roamingCallback?.(5);
-                setInterval(() => this.roamingCallback?.(5), Modules.MobDefaults.ROAM_FREQUENCY);
+                this.roamingCallback?.(Modules.MobDefaults.ROAM_RETRIES);
+                setInterval(
+                    () => this.roamingCallback?.(Modules.MobDefaults.ROAM_RETRIES),
+                    Modules.MobDefaults.ROAM_FREQUENCY
+                );
             }, Utils.randomInt(0, Modules.MobDefaults.ROAM_FREQUENCY - 1));
     }
 


### PR DESCRIPTION
### Motivation

Because looking for a new spot while roaming easily fails atm resulting in the mob staying in the same spot, some recursion was added. This makes the roaming call much more reliable and makes the world seem more alive.