### PR TITLE
added mongodb auth source implementation.

### DIFF
--- a/.env.defaults
+++ b/.env.defaults
@@ -61,6 +61,8 @@ MONGODB_DATABASE='kaetram_devlopment'
 MONGODB_TLS=false
 # Use the `mongodb+srv` syntax
 MONGODB_SRV=false
+# If you need to authenticate against a different database
+MONGODB_AUTH_SOURCE=''
 # When we're allowed to aggregate new data.
 AGGREGATE_THRESHOLD=60000
 

--- a/packages/common/config.ts
+++ b/packages/common/config.ts
@@ -38,6 +38,7 @@ export interface Config {
     mongodbDatabase: string;
     mongodbSrv: boolean;
     mongodbTls: boolean;
+    mongodbAuthSource: string;
     aggregateThreshold: number;
 
     tutorialEnabled: boolean;

--- a/packages/common/database/database.ts
+++ b/packages/common/database/database.ts
@@ -21,7 +21,8 @@ export default class Database {
                     config.mongodbPassword,
                     config.mongodbDatabase,
                     config.mongodbTls,
-                    config.mongodbSrv
+                    config.mongodbSrv,
+                    config.mongodbAuthSource
                 );
                 break;
             }

--- a/packages/common/database/mongodb/mongodb.ts
+++ b/packages/common/database/mongodb/mongodb.ts
@@ -33,12 +33,15 @@ export default class MongoDB {
         password: string,
         private databaseName: string,
         private tls: boolean,
-        srv: boolean
+        srv: boolean,
+        private authSource: string
     ) {
         let srvInsert = srv ? 'mongodb+srv' : 'mongodb',
             authInsert = username && password ? `${username}:${password}@` : '',
-            portInsert = port > 0 ? `:${port}` : '';
-        this.connectionUrl = `${srvInsert}://${authInsert}${host}${portInsert}/${databaseName}`;
+            portInsert = port > 0 ? `:${port}` : '',
+            authSourceInsert = authSource ? `?authSource=${authSource}` : '';
+        this.connectionUrl = `${srvInsert}://${authInsert}${host}${portInsert}/${databaseName}${authSourceInsert}`;
+        console.log(this.connectionUrl);
 
         // Attempt to connect to MongoDB.
         this.createConnection();

--- a/packages/common/database/mongodb/mongodb.ts
+++ b/packages/common/database/mongodb/mongodb.ts
@@ -41,7 +41,6 @@ export default class MongoDB {
             portInsert = port > 0 ? `:${port}` : '',
             authSourceInsert = authSource ? `?authSource=${authSource}` : '';
         this.connectionUrl = `${srvInsert}://${authInsert}${host}${portInsert}/${databaseName}${authSourceInsert}`;
-        console.log(this.connectionUrl);
 
         // Attempt to connect to MongoDB.
         this.createConnection();


### PR DESCRIPTION
### Motivation

When I try to connect my Digitalocean Hosted DB instance, the auth source differs from the game database, which blocks me.

**How to test (feature)**

- Add a new Auth Database name from the .env file and re-run the application.

### Changes

Added new ability to check authentication from different databases for some hosted database solutions (Digitalocean etc.)
