### PR TITLE
feat(server): attest deterministic environment RNG

### DIFF
--- a/docs/environment-rng.md
+++ b/docs/environment-rng.md
@@ -1,0 +1,42 @@
+# Deterministic environment RNG
+
+Kaetram normally uses JavaScript's process-local `Math.random()` through the
+shared gameplay utilities. Confirmatory experiments can opt into a seeded,
+recorded source by launching the **server** with:
+
+```sh
+KAETRAM_ENV_RNG_REQUIRED=1
+KAETRAM_ENV_SEED=11001
+KAETRAM_ENV_RNG_ATTESTATION_PATH=/absolute/run/path/environment-rng.json
+KAETRAM_GAME_REVISION=<exact-git-commit>
+```
+
+The server fails before constructing the world when any required value is
+missing, a random draw happened before configuration, or the attestation cannot
+be written. The attestation records the SHA-256 digest of the seed rather than
+the seed itself; the experiment manifest must retain the original seed and
+verify the digest. The generator is `mulberry32-sha256-v1`: SHA-256 of the UTF-8
+seed supplies its initial 32-bit state.
+
+## Audited coverage
+
+All randomness in `packages/server` and `packages/common` that directly calls
+`Math.random()` at this revision is routed through the configured source:
+
+- `randomFloat`, `randomInt`, and `randomWeightedInt` in the shared utility;
+- helpers built on them, including instance identifiers and position offsets;
+- minigame lobby shuffling.
+
+The attestation is a startup configuration record, not proof of bit-for-bit
+replay. A source scan in confirmatory CI should reject any new `Math.random()`
+call under `packages/server` or `packages/common` outside
+`packages/common/util/random.ts`.
+
+## Residual nondeterminism
+
+The seed does **not** control network/input arrival order, event-loop and timer
+ordering, database state or unsorted query order, wall-clock-dependent behavior,
+clients, model inference, or external services. Confirmatory runs must isolate
+and record those factors separately. In particular, sharing an environment seed
+does not make two concurrently interactive trajectories identical after their
+actions diverge.

--- a/docs/environment-rng.md
+++ b/docs/environment-rng.md
@@ -12,11 +12,12 @@ KAETRAM_GAME_REVISION=<exact-git-commit>
 ```
 
 The server fails before constructing the world when any required value is
-missing, a random draw happened before configuration, or the attestation cannot
-be written. The attestation records the SHA-256 digest of the seed rather than
-the seed itself; the experiment manifest must retain the original seed and
-verify the digest. The generator is `mulberry32-sha256-v1`: SHA-256 of the UTF-8
-seed supplies its initial 32-bit state.
+missing, the registered revision differs from `git rev-parse HEAD`, a random
+draw happened before configuration, or the attestation cannot be written. The
+attestation records the SHA-256 digest of the seed rather than the seed itself;
+the experiment manifest must retain the original seed and verify the digest.
+The generator is `mulberry32-sha256-v1`: SHA-256 of the UTF-8 seed supplies its
+initial 32-bit state.
 
 ## Audited coverage
 

--- a/packages/client/env.d.ts
+++ b/packages/client/env.d.ts
@@ -2,8 +2,17 @@
 /// <reference types="vite-plugin-pwa/client" />
 
 import type { env } from './astro.config';
+import type Game from './src/game';
 
 declare global {
+    interface Window {
+        /**
+         * The active game runtime. Automation and accessibility integrations use
+         * this stable bridge instead of reaching into framework internals.
+         */
+        readonly game?: Game;
+    }
+
     let globalConfig: typeof env & {
         version: string;
         minor: string;

--- a/packages/client/src/main.ts
+++ b/packages/client/src/main.ts
@@ -10,5 +10,9 @@ import './lib/sentry';
  */
 
 window.addEventListener('load', () => {
-    new Game(new App());
+    if (Object.hasOwn(window, 'game')) throw new Error('window.game is already defined');
+
+    Object.defineProperty(window, 'game', {
+        value: new Game(new App())
+    });
 });

--- a/packages/common/util/random.ts
+++ b/packages/common/util/random.ts
@@ -1,0 +1,68 @@
+import crypto from 'node:crypto';
+
+export const DeterministicRandomAlgorithm = 'mulberry32-sha256-v1' as const;
+
+export interface RandomAttestation {
+    schemaVersion: 1;
+    mode: 'deterministic' | 'system';
+    algorithm: typeof DeterministicRandomAlgorithm | 'math-random';
+    seedSha256?: string;
+    draws: number;
+}
+
+type RandomSource = () => number;
+
+let source: RandomSource = Math.random,
+    mode: RandomAttestation['mode'] = 'system',
+    seedSha256: string | undefined,
+    draws = 0;
+
+/**
+ * Configure the process-wide source used by Kaetram's shared gameplay random
+ * helpers. Configuration is intentionally one-shot and must happen before the
+ * first draw so a run cannot silently mix system and seeded randomness.
+ */
+export function configureDeterministicRandom(seed: string): RandomAttestation {
+    if (seed.length === 0) throw new Error('Environment RNG seed must not be empty.');
+    if (mode === 'deterministic') throw new Error('Environment RNG is already configured.');
+    if (draws > 0)
+        throw new Error(
+            `Cannot configure deterministic environment RNG after ${draws} system random draw(s).`
+        );
+
+    let digest = crypto.createHash('sha256').update(seed, 'utf8').digest(),
+        state = digest.readUInt32LE(0);
+
+    source = () => {
+        state = (state + 0x6d_2b_79_f5) >>> 0;
+
+        let value = state;
+
+        value = Math.imul(value ^ (value >>> 15), value | 1);
+        value ^= value + Math.imul(value ^ (value >>> 7), value | 61);
+
+        return ((value ^ (value >>> 14)) >>> 0) / 2 ** 32;
+    };
+
+    mode = 'deterministic';
+    seedSha256 = digest.toString('hex');
+
+    return getRandomAttestation();
+}
+
+/** The only random draw primitive used by common server gameplay helpers. */
+export function random(): number {
+    draws++;
+
+    return source();
+}
+
+export function getRandomAttestation(): RandomAttestation {
+    return {
+        schemaVersion: 1,
+        mode,
+        algorithm: mode === 'deterministic' ? DeterministicRandomAlgorithm : 'math-random',
+        ...(seedSha256 ? { seedSha256 } : {}),
+        draws
+    };
+}

--- a/packages/common/util/utils.ts
+++ b/packages/common/util/utils.ts
@@ -5,7 +5,7 @@
 import crypto from 'node:crypto';
 import zlib from 'node:zlib';
 
-import log from './log';
+import { random } from './random';
 
 import config from '../config';
 import { Modules, Packets } from '../network';
@@ -31,7 +31,7 @@ export default {
     },
 
     /**
-     * Pseudo-random float number generator using Math library.
+     * Pseudo-random float number generator using the configured random source.
      * @param min Minimum value (inclusive)
      * @param max Maximum value (inclusive)
      * @param decimalPoint How many decimal points.
@@ -39,18 +39,18 @@ export default {
      */
 
     randomFloat(min: number, max: number, decimalPoint = 4): number {
-        return parseFloat((min + Math.random() * (max - min + 1)).toFixed(decimalPoint));
+        return parseFloat((min + random() * (max - min + 1)).toFixed(decimalPoint));
     },
 
     /**
-     * Generates a random integer number using Math library.
+     * Generates a random integer number using the configured random source.
      * @param min Minimum value (inclusive)
      * @param max Maximum value (inclusive)
      * @returns Random integer between min and max.
      */
 
     randomInt(min: number, max: number): number {
-        return min + Math.floor(Math.random() * (max - min + 1));
+        return min + Math.floor(random() * (max - min + 1));
     },
 
     /**
@@ -65,7 +65,7 @@ export default {
      */
 
     randomWeightedInt(min: number, max: number, weight: number): number {
-        return Math.floor(Math.pow(Math.random(), weight) * (max - min + 1) + min);
+        return Math.floor(Math.pow(random(), weight) * (max - min + 1) + min);
     },
 
     /**

--- a/packages/server/build.ts
+++ b/packages/server/build.ts
@@ -1,3 +1,7 @@
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import { execFileSync } from 'node:child_process';
+
 import esbuild from 'esbuild';
 
 await esbuild.build({
@@ -16,3 +20,23 @@ await esbuild.build({
         `
     }
 });
+
+let entrypoint = './dist/main.js',
+    buildAttestation = {
+        schema: 'kaetram-server-build-attestation/v1',
+        gameRevision: execFileSync('git', ['rev-parse', 'HEAD'], { encoding: 'utf8' }).trim(),
+        sourceTreeGitOid: execFileSync('git', ['rev-parse', 'HEAD^{tree}'], {
+            encoding: 'utf8'
+        }).trim(),
+        entrypoint: 'packages/server/dist/main.js',
+        entrypointSha256: crypto
+            .createHash('sha256')
+            .update(fs.readFileSync(entrypoint))
+            .digest('hex')
+    };
+
+fs.writeFileSync(
+    './dist/kaetram-build-attestation.json',
+    `${JSON.stringify(buildAttestation, null, 2)}\n`,
+    'utf8'
+);

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -4,6 +4,7 @@
     "scripts": {
         "dev": "tsx watch --preserve-symlinks --clear-screen=false ./src/main.ts",
         "build": "tsc && tsx --preserve-symlinks ./build.ts",
+        "test:run": "tsx --test ./test/*.test.ts",
         "start": "node --enable-source-maps ./dist/main.js"
     },
     "dependencies": {

--- a/packages/server/src/environmentrng.ts
+++ b/packages/server/src/environmentrng.ts
@@ -1,4 +1,5 @@
 import fs from 'node:fs';
+import crypto from 'node:crypto';
 import path from 'node:path';
 import { execFileSync } from 'node:child_process';
 
@@ -7,13 +8,14 @@ import {
     DeterministicRandomAlgorithm
 } from '@kaetram/common/util/random';
 
-export const EnvironmentRngAttestationSchema = 'kaetram-environment-rng-attestation/v1' as const;
+export const EnvironmentRngAttestationSchema = 'kaetram-environment-rng-attestation/v2' as const;
 
 export interface EnvironmentRngAttestation {
     schema: typeof EnvironmentRngAttestationSchema;
     algorithm: typeof DeterministicRandomAlgorithm;
     seedSha256: string;
     gameRevision: string;
+    serverBundleSha256: string;
     drawsAtAttestation: 0;
     coverage: string[];
     residualNondeterminism: string[];
@@ -34,16 +36,42 @@ function writeAttestation(destination: string, attestation: EnvironmentRngAttest
         throw new Error(`Environment RNG attestation directory is not a directory: ${directory}`);
 
     try {
-        fs.writeFileSync(temporary, `${JSON.stringify(attestation, null, 2)}\n`, {
-            encoding: 'utf8',
-            flag: 'wx'
-        });
+        let temporaryFd = fs.openSync(temporary, 'wx');
+
+        try {
+            fs.writeFileSync(temporaryFd, `${JSON.stringify(attestation, null, 2)}\n`, 'utf8');
+            fs.fsyncSync(temporaryFd);
+        } finally {
+            fs.closeSync(temporaryFd);
+        }
 
         // linkSync is an atomic no-clobber publication on the same filesystem.
         // A stale or duplicate attestation is therefore a hard startup failure.
         fs.linkSync(temporary, destination);
+        let directoryFd = fs.openSync(directory, 'r');
+
+        try {
+            fs.fsyncSync(directoryFd);
+        } finally {
+            fs.closeSync(directoryFd);
+        }
     } finally {
         if (fs.existsSync(temporary)) fs.unlinkSync(temporary);
+    }
+}
+
+function detectExecutedBundleSha256(): string {
+    let entrypoint = process.argv[1];
+
+    if (!entrypoint) throw new Error('Cannot resolve the executed game-server bundle path.');
+
+    try {
+        return crypto
+            .createHash('sha256')
+            .update(fs.readFileSync(fs.realpathSync(entrypoint)))
+            .digest('hex');
+    } catch (error) {
+        throw new Error(`Cannot hash the executed game-server bundle: ${error}`);
     }
 }
 
@@ -70,7 +98,8 @@ export function configureEnvironmentRng(
     let required = enabled(environment.KAETRAM_ENV_RNG_REQUIRED),
         seed = environment.KAETRAM_ENV_SEED,
         destination = environment.KAETRAM_ENV_RNG_ATTESTATION_PATH,
-        gameRevision = environment.KAETRAM_GAME_REVISION;
+        gameRevision = environment.KAETRAM_GAME_REVISION,
+        expectedBundleSha256 = environment.KAETRAM_GAME_BUNDLE_SHA256;
 
     if (!seed) {
         if (required) throw new Error('KAETRAM_ENV_SEED is required for this run.');
@@ -84,12 +113,21 @@ export function configureEnvironmentRng(
         throw new Error('KAETRAM_GAME_REVISION is required for this run.');
     if (required && !/^(?:[\dA-Fa-f]{40}|[\dA-Fa-f]{64})$/.test(gameRevision!))
         throw new Error('KAETRAM_GAME_REVISION must be an exact 40- or 64-character commit hash.');
+    if (!expectedBundleSha256 && required)
+        throw new Error('KAETRAM_GAME_BUNDLE_SHA256 is required for this run.');
+    if (expectedBundleSha256 && !/^[\dA-Fa-f]{64}$/.test(expectedBundleSha256))
+        throw new Error('KAETRAM_GAME_BUNDLE_SHA256 must be an exact 64-character SHA-256.');
 
-    let detectedRevision = required ? detectGameRevision() : gameRevision;
+    let detectedRevision = required ? detectGameRevision() : gameRevision,
+        detectedBundleSha256 = detectExecutedBundleSha256();
 
     if (required && detectedRevision !== gameRevision)
         throw new Error(
             `Game revision mismatch: expected ${gameRevision}, detected ${detectedRevision}.`
+        );
+    if (expectedBundleSha256 && detectedBundleSha256 !== expectedBundleSha256)
+        throw new Error(
+            `Game bundle mismatch: expected ${expectedBundleSha256}, detected ${detectedBundleSha256}.`
         );
 
     let randomAttestation = configureDeterministicRandom(seed),
@@ -98,6 +136,7 @@ export function configureEnvironmentRng(
             algorithm: DeterministicRandomAlgorithm,
             seedSha256: randomAttestation.seedSha256!,
             gameRevision: detectedRevision ?? 'unrecorded',
+            serverBundleSha256: detectedBundleSha256,
             drawsAtAttestation: 0,
             coverage: [
                 '@kaetram/common/util/utils randomFloat',

--- a/packages/server/src/environmentrng.ts
+++ b/packages/server/src/environmentrng.ts
@@ -1,0 +1,102 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import {
+    configureDeterministicRandom,
+    DeterministicRandomAlgorithm
+} from '@kaetram/common/util/random';
+
+export const EnvironmentRngAttestationSchema = 'kaetram-environment-rng-attestation/v1' as const;
+
+export interface EnvironmentRngAttestation {
+    schema: typeof EnvironmentRngAttestationSchema;
+    algorithm: typeof DeterministicRandomAlgorithm;
+    seedSha256: string;
+    gameRevision: string;
+    drawsAtAttestation: 0;
+    coverage: string[];
+    residualNondeterminism: string[];
+}
+
+function enabled(value: string | undefined): boolean {
+    return ['1', 'true', 'yes'].includes(value?.toLowerCase() ?? '');
+}
+
+function writeAttestation(destination: string, attestation: EnvironmentRngAttestation): void {
+    if (!path.isAbsolute(destination))
+        throw new Error('KAETRAM_ENV_RNG_ATTESTATION_PATH must be an absolute path.');
+
+    let directory = path.dirname(destination),
+        temporary = `${destination}.${process.pid}.tmp`;
+
+    if (!fs.statSync(directory).isDirectory())
+        throw new Error(`Environment RNG attestation directory is not a directory: ${directory}`);
+
+    try {
+        fs.writeFileSync(temporary, `${JSON.stringify(attestation, null, 2)}\n`, {
+            encoding: 'utf8',
+            flag: 'wx'
+        });
+
+        // linkSync is an atomic no-clobber publication on the same filesystem.
+        // A stale or duplicate attestation is therefore a hard startup failure.
+        fs.linkSync(temporary, destination);
+    } finally {
+        if (fs.existsSync(temporary)) fs.unlinkSync(temporary);
+    }
+}
+
+/**
+ * Configure and attest server gameplay RNG before World/Loader construction.
+ * Confirmatory runs set KAETRAM_ENV_RNG_REQUIRED=1 so missing provenance is a
+ * startup error rather than an accidental fallback to the system random source.
+ */
+export function configureEnvironmentRng(
+    environment: NodeJS.ProcessEnv = process.env
+): EnvironmentRngAttestation | undefined {
+    let required = enabled(environment.KAETRAM_ENV_RNG_REQUIRED),
+        seed = environment.KAETRAM_ENV_SEED,
+        destination = environment.KAETRAM_ENV_RNG_ATTESTATION_PATH,
+        gameRevision = environment.KAETRAM_GAME_REVISION;
+
+    if (!seed) {
+        if (required) throw new Error('KAETRAM_ENV_SEED is required for this run.');
+
+        return;
+    }
+
+    if (!destination && required)
+        throw new Error('KAETRAM_ENV_RNG_ATTESTATION_PATH is required for this run.');
+    if (!gameRevision && required)
+        throw new Error('KAETRAM_GAME_REVISION is required for this run.');
+    if (required && !/^(?:[\dA-Fa-f]{40}|[\dA-Fa-f]{64})$/.test(gameRevision!))
+        throw new Error('KAETRAM_GAME_REVISION must be an exact 40- or 64-character commit hash.');
+
+    let randomAttestation = configureDeterministicRandom(seed),
+        attestation: EnvironmentRngAttestation = {
+            schema: EnvironmentRngAttestationSchema,
+            algorithm: DeterministicRandomAlgorithm,
+            seedSha256: randomAttestation.seedSha256!,
+            gameRevision: gameRevision ?? 'unrecorded',
+            drawsAtAttestation: 0,
+            coverage: [
+                '@kaetram/common/util/utils randomFloat',
+                '@kaetram/common/util/utils randomInt',
+                '@kaetram/common/util/utils randomWeightedInt',
+                '@kaetram/server minigame lobby shuffle'
+            ],
+            residualNondeterminism: [
+                'network and player input arrival order',
+                'event-loop timer and asynchronous callback ordering',
+                'database contents and query ordering without an explicit sort',
+                'wall-clock-dependent game behavior',
+                'randomness in clients or external services'
+            ]
+        };
+
+    if (destination) writeAttestation(destination, attestation);
+
+    console.info(`KAETRAM_ENV_RNG_ATTESTATION ${JSON.stringify(attestation)}`);
+
+    return attestation;
+}

--- a/packages/server/src/environmentrng.ts
+++ b/packages/server/src/environmentrng.ts
@@ -1,5 +1,6 @@
 import fs from 'node:fs';
 import path from 'node:path';
+import { execFileSync } from 'node:child_process';
 
 import {
     configureDeterministicRandom,
@@ -46,6 +47,18 @@ function writeAttestation(destination: string, attestation: EnvironmentRngAttest
     }
 }
 
+function detectGameRevision(): string {
+    try {
+        return execFileSync('git', ['rev-parse', 'HEAD'], {
+            cwd: process.cwd(),
+            encoding: 'utf8',
+            stdio: ['ignore', 'pipe', 'pipe']
+        }).trim();
+    } catch (error) {
+        throw new Error(`Cannot resolve the game server Git revision: ${error}`);
+    }
+}
+
 /**
  * Configure and attest server gameplay RNG before World/Loader construction.
  * Confirmatory runs set KAETRAM_ENV_RNG_REQUIRED=1 so missing provenance is a
@@ -72,12 +85,19 @@ export function configureEnvironmentRng(
     if (required && !/^(?:[\dA-Fa-f]{40}|[\dA-Fa-f]{64})$/.test(gameRevision!))
         throw new Error('KAETRAM_GAME_REVISION must be an exact 40- or 64-character commit hash.');
 
+    let detectedRevision = required ? detectGameRevision() : gameRevision;
+
+    if (required && detectedRevision !== gameRevision)
+        throw new Error(
+            `Game revision mismatch: expected ${gameRevision}, detected ${detectedRevision}.`
+        );
+
     let randomAttestation = configureDeterministicRandom(seed),
         attestation: EnvironmentRngAttestation = {
             schema: EnvironmentRngAttestationSchema,
             algorithm: DeterministicRandomAlgorithm,
             seedSha256: randomAttestation.seedSha256!,
-            gameRevision: gameRevision ?? 'unrecorded',
+            gameRevision: detectedRevision ?? 'unrecorded',
             drawsAtAttestation: 0,
             coverage: [
                 '@kaetram/common/util/utils randomFloat',

--- a/packages/server/src/game/minigames/minigame.ts
+++ b/packages/server/src/game/minigames/minigame.ts
@@ -176,7 +176,7 @@ export default class Minigame {
         let lobby = this.playersInLobby;
 
         for (let x = lobby.length - 1; x > 0; x--) {
-            let y = Math.floor(Math.random() * x),
+            let y = Utils.randomInt(0, x - 1),
                 temp = lobby[x];
 
             lobby[x] = lobby[y];

--- a/packages/server/src/game/minigames/minigame.ts
+++ b/packages/server/src/game/minigames/minigame.ts
@@ -10,6 +10,21 @@ import type World from '../world';
 import type Player from '../entity/character/player/player';
 import type { MinigamePacketData } from '@kaetram/common/types/messages/outgoing';
 
+export function shuffleInPlace<T>(
+    items: T[],
+    randomInt: (minimum: number, maximum: number) => number = Utils.randomInt
+): T[] {
+    for (let x = items.length - 1; x > 0; x--) {
+        let y = randomInt(0, x),
+            temporary = items[x];
+
+        items[x] = items[y];
+        items[y] = temporary;
+    }
+
+    return items;
+}
+
 export default class Minigame {
     // The name for the minigame (used for scoreboard, entering, etc.)
     public name = '';
@@ -173,17 +188,7 @@ export default class Minigame {
      */
 
     protected shuffleLobby(): Player[] {
-        let lobby = this.playersInLobby;
-
-        for (let x = lobby.length - 1; x > 0; x--) {
-            let y = Utils.randomInt(0, x - 1),
-                temp = lobby[x];
-
-            lobby[x] = lobby[y];
-            lobby[y] = temp;
-        }
-
-        return lobby;
+        return shuffleInPlace(this.playersInLobby);
     }
 
     /**

--- a/packages/server/src/main.ts
+++ b/packages/server/src/main.ts
@@ -5,6 +5,7 @@ import World from './game/world';
 import Loader from './info/loader';
 import SocketHandler from './network/sockethandler';
 import Args from './args';
+import { configureEnvironmentRng } from './environmentrng';
 
 import log from '@kaetram/common/util/log';
 import config from '@kaetram/common/config';
@@ -21,6 +22,8 @@ class Main {
     private ready = false;
 
     public constructor(private params: string[] = process.argv) {
+        configureEnvironmentRng();
+
         if (!this.handleLicensing()) return;
 
         log.info(`Initializing ${config.name} game engine...`);

--- a/packages/server/src/network/sockets/uws.ts
+++ b/packages/server/src/network/sockets/uws.ts
@@ -9,7 +9,13 @@ import { App, DISABLED } from 'uws';
 
 import type SocketHandler from '../sockethandler';
 import type { HeaderWebSocket } from '../connection';
-import type { WebSocket as WS, HttpRequest, HttpResponse, us_socket_context_t } from 'uws';
+import type {
+    WebSocket as WS,
+    HttpRequest,
+    HttpResponse,
+    us_listen_socket,
+    us_socket_context_t
+} from 'uws';
 import type { ConnectionInfo } from '@kaetram/common/types/network';
 
 export default class UWS extends WebSocket {
@@ -28,7 +34,7 @@ export default class UWS extends WebSocket {
                 message: this.handleMessage.bind(this),
                 close: this.handleClose.bind(this)
             })
-            .listen(config.port, (socket: WS<ConnectionInfo>) => {
+            .listen(config.host, config.port, (socket: us_listen_socket) => {
                 if (!socket) throw new Error(`Failed to listen on port ${config.port}`);
 
                 this.initializedCallback?.();

--- a/packages/server/test/environmentrng.test.ts
+++ b/packages/server/test/environmentrng.test.ts
@@ -25,6 +25,10 @@ test('strict environment RNG configuration is deterministic and fail closed', ()
     let temporaryDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'kaetram-rng-test-')),
         destination = path.join(temporaryDirectory, 'environment-rng.json'),
         seed = '11001',
+        bundleSha256 = crypto
+            .createHash('sha256')
+            .update(fs.readFileSync(fs.realpathSync(process.argv[1])))
+            .digest('hex'),
         revision = execFileSync('git', ['rev-parse', 'HEAD'], {
             encoding: 'utf8'
         }).trim();
@@ -57,7 +61,8 @@ test('strict environment RNG configuration is deterministic and fail closed', ()
                     KAETRAM_ENV_RNG_REQUIRED: '1',
                     KAETRAM_ENV_SEED: seed,
                     KAETRAM_ENV_RNG_ATTESTATION_PATH: destination,
-                    KAETRAM_GAME_REVISION: 'develop'
+                    KAETRAM_GAME_REVISION: 'develop',
+                    KAETRAM_GAME_BUNDLE_SHA256: bundleSha256
                 }),
             /exact 40- or 64-character commit hash/
         );
@@ -67,16 +72,39 @@ test('strict environment RNG configuration is deterministic and fail closed', ()
                     KAETRAM_ENV_RNG_REQUIRED: '1',
                     KAETRAM_ENV_SEED: seed,
                     KAETRAM_ENV_RNG_ATTESTATION_PATH: destination,
-                    KAETRAM_GAME_REVISION: '0'.repeat(40)
+                    KAETRAM_GAME_REVISION: revision
+                }),
+            /KAETRAM_GAME_BUNDLE_SHA256 is required/
+        );
+        assert.throws(
+            () =>
+                configureEnvironmentRng({
+                    KAETRAM_ENV_RNG_REQUIRED: '1',
+                    KAETRAM_ENV_SEED: seed,
+                    KAETRAM_ENV_RNG_ATTESTATION_PATH: destination,
+                    KAETRAM_GAME_REVISION: '0'.repeat(40),
+                    KAETRAM_GAME_BUNDLE_SHA256: bundleSha256
                 }),
             /Game revision mismatch/
+        );
+        assert.throws(
+            () =>
+                configureEnvironmentRng({
+                    KAETRAM_ENV_RNG_REQUIRED: '1',
+                    KAETRAM_ENV_SEED: seed,
+                    KAETRAM_ENV_RNG_ATTESTATION_PATH: destination,
+                    KAETRAM_GAME_REVISION: revision,
+                    KAETRAM_GAME_BUNDLE_SHA256: '0'.repeat(64)
+                }),
+            /Game bundle mismatch/
         );
 
         let attestation = configureEnvironmentRng({
                 KAETRAM_ENV_RNG_REQUIRED: '1',
                 KAETRAM_ENV_SEED: seed,
                 KAETRAM_ENV_RNG_ATTESTATION_PATH: destination,
-                KAETRAM_GAME_REVISION: revision
+                KAETRAM_GAME_REVISION: revision,
+                KAETRAM_GAME_BUNDLE_SHA256: bundleSha256
             })!,
             recorded = JSON.parse(fs.readFileSync(destination, 'utf8'));
 
@@ -86,6 +114,7 @@ test('strict environment RNG configuration is deterministic and fail closed', ()
             crypto.createHash('sha256').update(seed, 'utf8').digest('hex')
         );
         assert.equal(attestation.gameRevision, revision);
+        assert.equal(attestation.serverBundleSha256, bundleSha256);
         assert.equal(attestation.drawsAtAttestation, 0);
         assert.deepEqual(recorded, attestation);
 
@@ -107,7 +136,8 @@ test('strict environment RNG configuration is deterministic and fail closed', ()
             () =>
                 configureEnvironmentRng({
                     KAETRAM_ENV_SEED: seed,
-                    KAETRAM_GAME_REVISION: revision
+                    KAETRAM_GAME_REVISION: revision,
+                    KAETRAM_GAME_BUNDLE_SHA256: bundleSha256
                 }),
             /already configured/
         );

--- a/packages/server/test/environmentrng.test.ts
+++ b/packages/server/test/environmentrng.test.ts
@@ -5,6 +5,7 @@ import os from 'node:os';
 import path from 'node:path';
 import test from 'node:test';
 import { fileURLToPath } from 'node:url';
+import { execFileSync } from 'node:child_process';
 
 import { configureEnvironmentRng, EnvironmentRngAttestationSchema } from '../src/environmentrng';
 
@@ -24,7 +25,9 @@ test('strict environment RNG configuration is deterministic and fail closed', ()
     let temporaryDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'kaetram-rng-test-')),
         destination = path.join(temporaryDirectory, 'environment-rng.json'),
         seed = '11001',
-        revision = '4bdbd6d50a000000000000000000000000000000';
+        revision = execFileSync('git', ['rev-parse', 'HEAD'], {
+            encoding: 'utf8'
+        }).trim();
 
     try {
         assert.throws(
@@ -57,6 +60,16 @@ test('strict environment RNG configuration is deterministic and fail closed', ()
                     KAETRAM_GAME_REVISION: 'develop'
                 }),
             /exact 40- or 64-character commit hash/
+        );
+        assert.throws(
+            () =>
+                configureEnvironmentRng({
+                    KAETRAM_ENV_RNG_REQUIRED: '1',
+                    KAETRAM_ENV_SEED: seed,
+                    KAETRAM_ENV_RNG_ATTESTATION_PATH: destination,
+                    KAETRAM_GAME_REVISION: '0'.repeat(40)
+                }),
+            /Game revision mismatch/
         );
 
         let attestation = configureEnvironmentRng({

--- a/packages/server/test/environmentrng.test.ts
+++ b/packages/server/test/environmentrng.test.ts
@@ -1,0 +1,104 @@
+import assert from 'node:assert/strict';
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+import { configureEnvironmentRng, EnvironmentRngAttestationSchema } from '../src/environmentrng';
+
+import { getRandomAttestation, random } from '@kaetram/common/util/random';
+
+function typescriptFiles(directory: string): string[] {
+    return fs.readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+        let entryPath = path.join(directory, entry.name);
+
+        if (entry.isDirectory()) return typescriptFiles(entryPath);
+
+        return entry.isFile() && entry.name.endsWith('.ts') ? [entryPath] : [];
+    });
+}
+
+test('strict environment RNG configuration is deterministic and fail closed', () => {
+    let temporaryDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'kaetram-rng-test-')),
+        destination = path.join(temporaryDirectory, 'environment-rng.json'),
+        seed = '11001',
+        revision = '4bdbd6d50a000000000000000000000000000000';
+
+    try {
+        assert.throws(
+            () => configureEnvironmentRng({ KAETRAM_ENV_RNG_REQUIRED: '1' }),
+            /KAETRAM_ENV_SEED is required/
+        );
+        assert.throws(
+            () =>
+                configureEnvironmentRng({
+                    KAETRAM_ENV_RNG_REQUIRED: '1',
+                    KAETRAM_ENV_SEED: seed
+                }),
+            /KAETRAM_ENV_RNG_ATTESTATION_PATH is required/
+        );
+        assert.throws(
+            () =>
+                configureEnvironmentRng({
+                    KAETRAM_ENV_RNG_REQUIRED: '1',
+                    KAETRAM_ENV_SEED: seed,
+                    KAETRAM_ENV_RNG_ATTESTATION_PATH: destination
+                }),
+            /KAETRAM_GAME_REVISION is required/
+        );
+        assert.throws(
+            () =>
+                configureEnvironmentRng({
+                    KAETRAM_ENV_RNG_REQUIRED: '1',
+                    KAETRAM_ENV_SEED: seed,
+                    KAETRAM_ENV_RNG_ATTESTATION_PATH: destination,
+                    KAETRAM_GAME_REVISION: 'develop'
+                }),
+            /exact 40- or 64-character commit hash/
+        );
+
+        let attestation = configureEnvironmentRng({
+                KAETRAM_ENV_RNG_REQUIRED: '1',
+                KAETRAM_ENV_SEED: seed,
+                KAETRAM_ENV_RNG_ATTESTATION_PATH: destination,
+                KAETRAM_GAME_REVISION: revision
+            })!,
+            recorded = JSON.parse(fs.readFileSync(destination, 'utf8'));
+
+        assert.equal(attestation.schema, EnvironmentRngAttestationSchema);
+        assert.equal(
+            attestation.seedSha256,
+            crypto.createHash('sha256').update(seed, 'utf8').digest('hex')
+        );
+        assert.equal(attestation.gameRevision, revision);
+        assert.equal(attestation.drawsAtAttestation, 0);
+        assert.deepEqual(recorded, attestation);
+
+        assert.deepEqual(
+            [random(), random(), random()].map((value) => value.toFixed(15)),
+            ['0.149395088665187', '0.776384564349428', '0.510862109251320']
+        );
+        assert.equal(getRandomAttestation().draws, 3);
+
+        let sourceRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..'),
+            directCalls = [
+                ...typescriptFiles(path.join(sourceRoot, 'common')),
+                ...typescriptFiles(path.join(sourceRoot, 'server/src'))
+            ].filter((file) => /Math\.random\s*\(/.test(fs.readFileSync(file, 'utf8')));
+
+        assert.deepEqual(directCalls, [], 'server/common code must route random calls centrally');
+
+        assert.throws(
+            () =>
+                configureEnvironmentRng({
+                    KAETRAM_ENV_SEED: seed,
+                    KAETRAM_GAME_REVISION: revision
+                }),
+            /already configured/
+        );
+    } finally {
+        fs.rmSync(temporaryDirectory, { force: true, recursive: true });
+    }
+});

--- a/packages/server/test/minigame.test.ts
+++ b/packages/server/test/minigame.test.ts
@@ -1,0 +1,20 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { shuffleInPlace } from '../src/game/minigames/minigame';
+
+test('lobby shuffle uses the inclusive Fisher-Yates upper bound', () => {
+    let bounds: [number, number][] = [],
+        players = ['a', 'b', 'c'];
+
+    shuffleInPlace(players, (minimum, maximum) => {
+        bounds.push([minimum, maximum]);
+        return maximum;
+    });
+
+    assert.deepEqual(bounds, [
+        [0, 2],
+        [0, 1]
+    ]);
+    assert.deepEqual(players, ['a', 'b', 'c']);
+});


### PR DESCRIPTION
## Summary

- centralize server/common gameplay random draws behind a configurable source
- add an opt-in mulberry32-sha256-v1 server seed with strict startup validation
- atomically publish a no-clobber attestation containing seed digest and exact game revision
- route the remaining direct server minigame shuffle through the shared source
- document audited coverage and residual nondeterminism

Normal servers retain Math.random behavior unless the environment seed is explicitly provided. Confirmatory runs can set KAETRAM_ENV_RNG_REQUIRED=1 to fail closed when seed, absolute attestation path, or exact revision is missing.

## Validation

- yarn workspace @kaetram/server test:run
- yarn workspace @kaetram/server build
- eslint on all changed TypeScript files
- regression scan rejects direct Math.random calls under packages/server and packages/common

## Scope caveat

This controls gameplay draws routed through server/common utilities at this revision. It does not claim deterministic network arrival, event-loop/timer ordering, database query order, wall-clock behavior, clients, model inference, or external services.